### PR TITLE
Update format.ts

### DIFF
--- a/format.ts
+++ b/format.ts
@@ -74,7 +74,7 @@ export function formatDateObj(
     }
     case "S": {
       return millisecond
-        ? millisecond <= 99 ? "0${millisecond}" : millisecond.toString()
+        ? millisecond <= 99 ? `0${millisecond}` : millisecond.toString()
         : "000";
     }
     case "w": {


### PR DESCRIPTION
When millisecond is less than zero the "S" formatting returns literally "0${millisecond}" rather than performing variable substitution.